### PR TITLE
feature/BRI-34

### DIFF
--- a/packages/client/src/components/core/ErrorBoundary/ErrorBoundary.tsx
+++ b/packages/client/src/components/core/ErrorBoundary/ErrorBoundary.tsx
@@ -1,0 +1,35 @@
+import { Component, ErrorInfo, ReactNode, ReactElement } from 'react'
+
+interface Props {
+  children: ReactElement;
+  fallback?: ReactElement | ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  public state = {
+    hasError: false
+  };
+
+  public static getDerivedStateFromError(): State {
+    return {
+      hasError: true
+    };
+  }
+
+  /* Оставлен для отладки */
+  public componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Ошибка:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.props.fallback || <p>Что-то пошло не так...</p>;
+    }
+
+    return this.props.children;
+  }
+}

--- a/packages/client/src/components/core/ErrorBoundary/index.tsx
+++ b/packages/client/src/components/core/ErrorBoundary/index.tsx
@@ -1,0 +1,1 @@
+export { ErrorBoundary } from './ErrorBoundary';


### PR DESCRIPTION
## Реализация компонента ErrorBoundary для обработки ошибок
Если есть компонент, в котором может возникнуть ошибка, его можно обернуть в ErrorBoundary. И передать туда fallback - разметку для вывода ошибки. Если fallback'а нет, то будет использован fallback по умолчанию `<p>Что-то пошло не так...</p>`

## Скриншоты/видяшка (если есть)

### Пример использования
<img width="204" alt="Screen Shot 2023-03-25 at 18 48 30" src="https://user-images.githubusercontent.com/23001740/227727754-855216f1-b779-4b34-832c-75df567e4bc2.png">
<img width="462" alt="Screen Shot 2023-03-25 at 18 48 38" src="https://user-images.githubusercontent.com/23001740/227727727-9453eab3-0b38-4c5c-bd38-eed171d826ee.png">

### Результат использования

#### По умолчанию
<img width="426" alt="Screen Shot 2023-03-25 at 18 55 49" src="https://user-images.githubusercontent.com/23001740/227728245-fa0e2c13-0870-4627-b313-79a15b317d08.png">

#### С ошибкой без обертки ErrorBoundary
<img width="449" alt="Screen Shot 2023-03-25 at 18 55 17" src="https://user-images.githubusercontent.com/23001740/227728215-582bcff3-c1d9-4718-9b08-aea328daae6d.png">

#### С оберткой ErrorBoundary
<img width="414" alt="Screen Shot 2023-03-25 at 18 55 34" src="https://user-images.githubusercontent.com/23001740/227728199-a92c3273-72a7-4ffb-a866-367ab8a22eaf.png">
